### PR TITLE
fix: correct go bindings

### DIFF
--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -3,8 +3,8 @@ package tree_sitter_query_test
 import (
 	"testing"
 
-	tree_sitter "github.com/smacker/go-tree-sitter"
-	"github.com/tree-sitter-grammars/tree-sitter-query"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	tree_sitter_query "github.com/tree-sitter-grammars/tree-sitter-query/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,5 +1,0 @@
-module github.com/tree-sitter-grammars/tree-sitter-query
-
-go 1.22
-
-require github.com/smacker/go-tree-sitter v0.0.0-20230720070738-0d0a9f78d8f8

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/tree-sitter-grammars/tree-sitter-query
+
+go 1.22
+
+require github.com/tree-sitter/go-tree-sitter v0.23.1

--- a/package.json
+++ b/package.json
@@ -53,16 +53,5 @@
     "test": "make test",
     "version": "make -s update",
     "prebuildify": "prebuildify --napi --strip"
-  },
-  "tree-sitter": [
-    {
-      "scope": "source.query",
-      "injection-regex": "^query$",
-      "highlights": "queries/query/highlights.scm",
-      "injections": "queries/query/injections.scm",
-      "file-types": [
-        "scm"
-      ]
-    }
-  ]
+  }
 }

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,40 @@
+{
+  "grammars": [
+    {
+      "name": "query",
+      "camelcase": "Query",
+      "scope": "source.query",
+      "path": ".",
+      "file-types": [
+        "scm"
+      ],
+      "highlights": "queries/query/highlights.scm",
+      "injections": "queries/query/injections.scm",
+      "injection-regex": "^query$"
+    }
+  ],
+  "metadata": {
+    "version": "0.4.0",
+    "license": "Apache-2.0",
+    "description": "TS query grammar for tree-sitter",
+    "authors": [
+      {
+        "name": "Steven Sojka"
+      },
+      {
+        "name": "Stephan Seitz"
+      }
+    ],
+    "links": {
+      "repository": "https://github.com/tree-sitter-grammars/tree-sitter-query"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}


### PR DESCRIPTION
Currently the go bindings do not work. This solution is based on https://github.com/tree-sitter/tree-sitter-c/commit/927da1f210ebb24b7f109230a61a55b428875985

This commit also regenerates the config file ~and bindings~ from `tree-sitter HEAD`