### PR TITLE
feat(npm)!: rename package to @tree-sitter-grammars/tree-sitter-query

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   npm:
     uses: tree-sitter/workflows/.github/workflows/package-npm.yml@main
+    with:
+      package-name: "@tree-sitter-grammars/tree-sitter-query"
     secrets:
       NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
   crates:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tree-sitter-query",
+  "name": "@tree-sitter-grammars/tree-sitter-query",
   "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tree-sitter-query",
+      "name": "@tree-sitter-grammars/tree-sitter-query",
       "version": "0.7.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tree-sitter-query",
+  "name": "@tree-sitter-grammars/tree-sitter-query",
   "version": "0.7.0",
   "description": "TS query grammar for tree-sitter",
   "repository": "https://github.com/tree-sitter-grammars/tree-sitter-query",
@@ -46,5 +46,8 @@
     "prestart": "tree-sitter build --wasm",
     "start": "tree-sitter playground",
     "test": "node --test bindings/node/*_test.js"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Problem: Cannot publish new versions on npmjs since tree-sitter-query package owner is unresponsive.

Solution: Publish packages as @tree-sitter-grammars/tree-sitter-query.